### PR TITLE
[BE] 모니터링 의존성 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -85,6 +85,12 @@ dependencies {
 
     // SwaggerUI
     swaggerUI 'org.webjars:swagger-ui:4.11.1'
+
+    // Actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // prometheus
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {


### PR DESCRIPTION


## 📝작업 내용

> `build.gradle`에 모니터링을 위한 `actuator`, `prometheus` 의존성 추가
